### PR TITLE
fix: unredacted some section header

### DIFF
--- a/MortyUI/Features/Characters/Detail/CharacterDetailView.swift
+++ b/MortyUI/Features/Characters/Detail/CharacterDetailView.swift
@@ -45,7 +45,7 @@ struct CharacterDetailView: View {
             locationSection
 
             if let episodes = character?.episode?.compactMap{ $0 } {
-                Section(header: Text("Episodes")) {
+              Section(header: Text("Episodes").unredacted()) {
                     ForEach(episodes, id: \.id) { episode in
                         NavigationLink(
                             destination: EpisodeDetailView(id: episode.id!),
@@ -68,7 +68,7 @@ struct CharacterDetailView: View {
     }
     
     private var infoSection: some View {
-        Section(header: Text("Info"),
+      Section(header: Text("Info").unredacted(),
                 content: {
                     InfoRowView(label: "Species",
                                 icon: "hare",
@@ -84,7 +84,7 @@ struct CharacterDetailView: View {
     }
     
     private var locationSection: some View {
-        Section(header: Text("Location")) {
+      Section(header: Text("Location").unredacted()) {
             NavigationLink(
                 destination:
                     LocationDetailView(id: character?.location?.id ?? GraphQLID(0)),

--- a/MortyUI/Features/Episodes/Detail/EpisodeDetailView.swift
+++ b/MortyUI/Features/Episodes/Detail/EpisodeDetailView.swift
@@ -22,7 +22,7 @@ struct EpisodeDetailView: View {
     
     var body: some View {
         List {
-            Section(header: Text("Info")) {
+          Section(header: Text("Info").unredacted()) {
                 InfoRowView(label: "Name",
                             icon: "info",
                             value: episode?.name ?? "loading...")

--- a/MortyUI/Features/Locations/Detail/LocationDetailView.swift
+++ b/MortyUI/Features/Locations/Detail/LocationDetailView.swift
@@ -22,7 +22,7 @@ struct LocationDetailView: View {
     
     var body: some View {
         List {
-            Section(header: Text("Info")) {
+          Section(header: Text("Info").unredacted()) {
                 InfoRowView(label: "Name",
                             icon: "info",
                             value: location?.name ?? "loading...")

--- a/MortyUI/Features/Search/SearchView.swift
+++ b/MortyUI/Features/Search/SearchView.swift
@@ -12,8 +12,8 @@ struct SearchView: View {
     
     var body: some View {
         NavigationView {
-            List {
-                Section {
+          List {
+            Section {
                     HStack {
                         TextField("Search", text: $viewModel.searchText)
                         if !viewModel.searchText.isEmpty {
@@ -42,7 +42,7 @@ struct SearchView: View {
                     }
                 }
                 if let locations = viewModel.locations {
-                    Section(header: Text("Locations")) {
+                  Section(header: Text("Locations")) {
                         ForEach(locations, id: \.id) { location in
                             NavigationLink(
                                 destination: LocationDetailView(id: location.id!),
@@ -63,7 +63,9 @@ struct SearchView: View {
                         }
                     }
                 }
-            }.navigationTitle("Search")
+            }
+          .navigationTitle("Search")
+          .listStyle(GroupedListStyle())
         }
     }
 }


### PR DESCRIPTION
I put the title of some sections not to be the skeleton. 
Like `Info`, `Locations` etc

Maybe we can write a more general way to reduce the duplicate code 🤔